### PR TITLE
Travis: Force updating homebrew on macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,6 +76,7 @@ matrix:
         homebrew:
           packages:
             - scons
+          update: true
 
     - name: iOS export template (debug, Clang)
       stage: build
@@ -86,6 +87,7 @@ matrix:
         homebrew:
           packages:
             - scons
+          update: true
 
     - name: Linux headless editor (release_debug, GCC 9, testing project exporting and script running)
       stage: build


### PR DESCRIPTION
Temporary workaround for https://travis-ci.community/t/macos-build-fails-because-of-homebrew-bundle-unknown-command/7296

(cherry picked from commit 1b01896e906042f284da95f3b7d48e72ce3b9c41)